### PR TITLE
Fix: Remove N+1 query for better performance - 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,12 +20,12 @@ group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem "rspec-rails"
   gem "pry-rails"
+  gem "faker"
 end
 
 group :development do
   gem "web-console"
   gem "annotate"
-  gem "faker"
 end
 
 group :test do
@@ -37,6 +37,7 @@ group :test do
   gem "rspec-its"
   gem "shoulda"
   gem "simplecov", require: false
+  gem 'rails-controller-testing'
 end
 
 # Use Redis for Action Cable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,10 @@ GEM
       activesupport (= 7.0.1)
       bundler (>= 1.15.0)
       railties (= 7.0.1)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -282,6 +286,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.1)
+  rails-controller-testing
   redis (~> 4.0)
   rspec-its
   rspec-rails

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -1,7 +1,7 @@
 class PeopleController < ApplicationController
 
   def index
-    @people = Person.all
+    @people = Person.includes(:company).all
   end
 
   def new

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -2,10 +2,22 @@ require 'rails_helper'
 
 RSpec.describe PeopleController, type: :controller do
   subject { response }
-  describe 'GET index' do
-    before { get :index }
+  describe "GET #index" do
+    let(:company) { create(:company) }
+    let(:person) { create(:person, company: company) }
 
-    it { is_expected.to have_http_status(:ok) }
+    it "assigns @people including associated companies" do
+      get :index
+
+      expect(assigns(:people)).to eq([person])  
+
+      expect(assigns(:people).first.company).to eq(company)
+    end
+
+    it "renders the index template" do
+      get :index
+      expect(response).to render_template("index")
+    end
   end
 
   describe 'GET new' do

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :company do
+    name { Faker::Company.name }
+  end
+end

--- a/spec/factories/persons.rb
+++ b/spec/factories/persons.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :person do
+    name { Faker::Name.name }
+    phone_number { Faker::PhoneNumber.phone_number }
+    email { Faker::Internet.email }
+    company
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,6 +36,8 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
+  config.include FactoryBot::Syntax::Methods
+  
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION
**Too many queries to the database, load Companies along with People.**

- Write test case for index action(eager loading of `company` to `person`) (Follow TDD approach ).
- Remove N+1 query issue from index action in people controller.