### PR TITLE
Feat: select an existing company when creating person entry - 6

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -6,6 +6,7 @@ class PeopleController < ApplicationController
 
   def new
     @person = Person.new
+    @companies = Company.all
   end
 
   def create
@@ -19,7 +20,7 @@ class PeopleController < ApplicationController
   private
 
   def person_attributes
-    params.require(:person).permit(:name, :email, :phone)
+    params.require(:person).permit(:name, :email, :phone_number, :company_id)
   end
 
 end

--- a/app/views/people/index.html.slim
+++ b/app/views/people/index.html.slim
@@ -13,7 +13,7 @@ table.table
       tr
         th[scope="row"]= person&.id
         td= person.try(:name)
-        td= person.try(:phone)
+        td= person.try(:phone_number)
         td= person.try(:email)
         td= person.try(:company).try(:name)
 

--- a/app/views/people/new.html.slim
+++ b/app/views/people/new.html.slim
@@ -1,17 +1,17 @@
 h2 Creating an entry
 
 = form_for @person, class: 'row' do |f|
-    .col-auto
-        = f.label :name, class: 'form-label'
-        = f.text_field :name, class: 'form-control'
-    .col-auto
-        = f.label :phone_number, class: 'form-label'
-        = f.text_field :phone_number, class: 'form-control'
-    .col-auto
-        = f.label :email, class: 'form-label'
-        = f.text_field :email, class: 'form-control'
-    .col-auto
-        = f.label :company_id, 'Company', class: 'form-label'
-        = f.collection_select :company_id, @companies, :id, :name, {}, { class: 'form-control' }
-    .col-auto.mt-4
-        = f.submit class: 'btn btn-primary'
+  .col-auto
+      = f.label :name, class: 'form-label'
+      = f.text_field :name, class: 'form-control'
+  .col-auto
+      = f.label :phone_number, class: 'form-label'
+      = f.text_field :phone_number, class: 'form-control'
+  .col-auto
+      = f.label :email, class: 'form-label'
+      = f.text_field :email, class: 'form-control'
+  .col-auto
+      = f.label :company_id, 'Company', class: 'form-label'
+      = f.collection_select :company_id, @companies, :id, :name, {}, { class: 'form-control' }
+  .col-auto.mt-4
+      = f.submit class: 'btn btn-primary'

--- a/app/views/people/new.html.slim
+++ b/app/views/people/new.html.slim
@@ -2,16 +2,16 @@ h2 Creating an entry
 
 = form_for @person, class: 'row' do |f|
   .col-auto
-      = f.label :name, class: 'form-label'
-      = f.text_field :name, class: 'form-control'
+    = f.label :name, class: 'form-label'
+    = f.text_field :name, class: 'form-control'
   .col-auto
-      = f.label :phone_number, class: 'form-label'
-      = f.text_field :phone_number, class: 'form-control'
+    = f.label :phone_number, class: 'form-label'
+    = f.text_field :phone_number, class: 'form-control'
   .col-auto
-      = f.label :email, class: 'form-label'
-      = f.text_field :email, class: 'form-control'
+    = f.label :email, class: 'form-label'
+    = f.text_field :email, class: 'form-control'
   .col-auto
-      = f.label :company_id, 'Company', class: 'form-label'
-      = f.collection_select :company_id, @companies, :id, :name, {}, { class: 'form-control' }
+    = f.label :company_id, 'Company', class: 'form-label'
+    = f.collection_select :company_id, @companies, :id, :name, {}, { class: 'form-control' }
   .col-auto.mt-4
-      = f.submit class: 'btn btn-primary'
+    = f.submit class: 'btn btn-primary'

--- a/app/views/people/new.html.slim
+++ b/app/views/people/new.html.slim
@@ -1,14 +1,17 @@
 h2 Creating an entry
 
 = form_for @person, class: 'row' do |f|
-  .col-auto
-    = f.label :name, class: 'form-label'
-    = f.text_field :name, class: 'form-control'
-  .col-auto
-    = f.label :phone_number, class: 'form-label'
-    = f.text_field :phone_number, class: 'form-control'
-  .col-auto
-    = f.label :email, class: 'form-label'
-    = f.text_field :email, class: 'form-control'
-  .col-auto.mt-4
-    = f.submit class: 'btn btn-primary'
+    .col-auto
+        = f.label :name, class: 'form-label'
+        = f.text_field :name, class: 'form-control'
+    .col-auto
+        = f.label :phone_number, class: 'form-label'
+        = f.text_field :phone_number, class: 'form-control'
+    .col-auto
+        = f.label :email, class: 'form-label'
+        = f.text_field :email, class: 'form-control'
+    .col-auto
+        = f.label :company_id, 'Company', class: 'form-label'
+        = f.collection_select :company_id, @companies, :id, :name, {}, { class: 'form-control' }
+    .col-auto.mt-4
+        = f.submit class: 'btn btn-primary'


### PR DESCRIPTION
**As a front-end user, when creating a new Person entry, I would like to be able to select an existing company**

- Added select field for select an existing company in the new Person entry.
- Added `company_id` in the params for saving in the database.