### PR TITLE
Feat: email should be match by entering twice in the person form - 8

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -9,17 +9,21 @@ class PeopleController < ApplicationController
   end
 
   def create
-    if Person.create(person_attributes)
+    @person = Person.new(person_attributes)
+    if @person.save
       redirect_to people_path, notice: 'Successfully created entry'
     else
-      render :create, alert: 'Unsuccessfully created entry'
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.replace(@person, partial: 'people/form', locals: { person: @person }) }
+        format.html { render :new }
+      end
     end
   end
 
   private
 
   def person_attributes
-    params.require(:person).permit(:name, :email, :phone)
+    params.require(:person).permit(:name, :email, :email_confirmation, :phone_number)
   end
 
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -14,4 +14,7 @@
 class Person < ApplicationRecord
   
   belongs_to :company, optional: true
+
+  attr_accessor :email_confirmation
+  validates :email, presence: true, uniqueness: true, confirmation: { case_sensitive: false }
 end

--- a/app/views/people/_form.html.slim
+++ b/app/views/people/_form.html.slim
@@ -1,0 +1,20 @@
+= form_for @person, class: 'row' do |f|
+  - if @person.errors.any?
+    .col-12
+      .alert.alert-danger
+        - @person.errors.full_messages.each do |message|
+          li = message
+  .col-auto
+    = f.label :name, class: 'form-label'
+    = f.text_field :name, class: 'form-control'
+  .col-auto
+    = f.label :phone_number, class: 'form-label'
+    = f.text_field :phone_number, class: 'form-control'
+  .col-auto
+    = f.label :email, class: 'form-label'
+    = f.email_field :email, class: 'form-control'
+  .col-auto
+    = f.label :email_confirmation, "Confirm Email", class: 'form-label'
+    = f.email_field :email_confirmation, class: 'form-control'
+  .col-auto.mt-4
+    = f.submit class: 'btn btn-primary'

--- a/app/views/people/new.html.slim
+++ b/app/views/people/new.html.slim
@@ -1,14 +1,2 @@
 h2 Creating an entry
-
-= form_for @person, class: 'row' do |f|
-  .col-auto
-    = f.label :name, class: 'form-label'
-    = f.text_field :name, class: 'form-control'
-  .col-auto
-    = f.label :phone_number, class: 'form-label'
-    = f.text_field :phone_number, class: 'form-control'
-  .col-auto
-    = f.label :email, class: 'form-label'
-    = f.text_field :email, class: 'form-control'
-  .col-auto.mt-4
-    = f.submit class: 'btn btn-primary'
+= render 'form', person: @person

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -14,6 +14,7 @@
 require 'rails_helper'
 
 RSpec.describe Person, type: :model do
+  it { is_expected.to belong_to(:company).optional }
   subject { described_class.new(name: 'John Doe', phone_number: '1234567890', email: 'john.doe@example.com', email_confirmation: 'john.doe@example.com') }
 
   it 'is valid with valid attributes' do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -14,5 +14,29 @@
 require 'rails_helper'
 
 RSpec.describe Person, type: :model do
-  it { is_expected.to belong_to(:company).optional }
+  subject { described_class.new(name: 'John Doe', phone_number: '1234567890', email: 'john.doe@example.com', email_confirmation: 'john.doe@example.com') }
+
+  it 'is valid with valid attributes' do
+    expect(subject).to be_valid
+  end
+
+  it 'is not valid without an email' do
+    subject.email = nil
+    expect(subject).to_not be_valid
+  end
+
+  it 'is not valid without an email confirmation' do
+    subject.email_confirmation = ""
+    expect(subject).to_not be_valid
+  end
+
+  it 'is not valid if email and email confirmation do not match' do
+    subject.email_confirmation = 'different.email@example.com'
+    expect(subject).to_not be_valid
+  end
+
+  it 'is not valid if email is not unique' do
+    described_class.create!(name: 'Jane Doe', phone_number: '0987654321', email: 'john.doe@example.com', email_confirmation: 'john.doe@example.com')
+    expect(subject).to_not be_valid
+  end
 end


### PR DESCRIPTION
**As a front-end user I want to make sure that the email I have entered is correct by entering it twice in the form**

- Added `attr_accessor`  for `email_confirmation` field.
- Write validation for both email field.
- Update person model test case for `email_confirmation`
- Displaying `email_confirmation` field in the form with showing error on unmatched emails