### PR TITLE
API:  endpoint that exposes People with filtering based on email, and pagination - 10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "jbuilder"
 gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 gem 'slim-rails'
 gem "jsbundling-rails"
+gem "kaminari"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,18 @@ GEM
       activesupport (>= 5.0.0)
     jsbundling-rails (1.0.0)
       railties (>= 6.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -279,6 +291,7 @@ DEPENDENCIES
   faker
   jbuilder
   jsbundling-rails
+  kaminari
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.1)

--- a/app/controllers/api/v1/people_controller.rb
+++ b/app/controllers/api/v1/people_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  module V1
+    class PeopleController < ApplicationController
+      def index
+        @people = Person.by_email(params[:email])
+
+        if @people.any?
+          @people = @people.page(params[:page]).per(params[:per_page])
+          render json: @people
+        else
+          render json: { message: 'No people found with the given email' }, status: :not_found
+        end
+      end
+    end
+  end
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -14,4 +14,6 @@
 class Person < ApplicationRecord
   
   belongs_to :company, optional: true
+
+  scope :by_email, -> (email) { where(email: email) if email.present? }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,10 @@ Rails.application.routes.draw do
 
   resources :people, only: [:index, :new, :create]
   root to: 'people#index'
+
+  namespace :api do
+    namespace :v1 do
+      resources :people, only: [:index]
+    end
+  end
 end

--- a/spec/controllers/api/v1/people_controller_spec.rb
+++ b/spec/controllers/api/v1/people_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::PeopleController, type: :controller do
+  describe 'GET #index' do
+    let!(:person) { Person.create(name: "abc", email: 'test@example.com', phone_number: "1232312") }
+
+    context 'when email exists' do
+      before { get :index, params: { email: 'test@example.com', page: 1, per_page: 10 } }
+
+      it 'returns the person with the given email' do
+        expect(JSON.parse(response.body).first['email']).to eq('test@example.com')
+      end
+
+      it 'returns status code 200' do
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'when email does not exist' do
+      before { get :index, params: { email: 'nonexistent@example.com', page: 1, per_page: 10 } }
+
+      it 'returns a not found message' do
+        expect(JSON.parse(response.body)['message']).to eq('No people found with the given email')
+      end
+
+      it 'returns status code 404' do
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -15,4 +15,26 @@ require 'rails_helper'
 
 RSpec.describe Person, type: :model do
   it { is_expected.to belong_to(:company).optional }
+  describe '.by_email' do
+    let!(:person) { Person.create(name: "abc", email: 'test@example.com', phone_number: "123423") }
+
+    context 'when email exists' do
+      it 'returns the person with the given email' do
+        expect(Person.by_email('test@example.com')).to include(person)
+      end
+    end
+
+    context 'when email does not exist' do
+      it 'returns an empty relation' do
+        expect(Person.by_email('nonexistent@example.com')).to be_empty
+      end
+    end
+
+    context 'when email is nil' do
+      it 'returns all people' do
+        other_person = Person.create(name: "xyz", email: 'other@example.com', phone_number: "123423")
+        expect(Person.by_email(nil)).to match_array([person, other_person])
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Create an API endpoint that exposes People to the public with filtering based on email, and pagination. Example GET request: { email: 'foo@bar.baz', page: 1, per_page: 10 }**

- Added endpoints for getting people based on email.
- Added scope in model for searching person with email.
- Added test case for both model and api controller.
- endpoints are `http://localhost:3000/api/v1/people?email=abc@abc.com&page=1&per_page=10`
