### PR TITLE
Api: Export endpoints for company by name with pagination - 11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "jbuilder"
 gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 gem 'slim-rails'
 gem "jsbundling-rails"
+gem "kaminari"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,18 @@ GEM
       activesupport (>= 5.0.0)
     jsbundling-rails (1.0.0)
       railties (>= 6.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -279,6 +291,7 @@ DEPENDENCIES
   faker
   jbuilder
   jsbundling-rails
+  kaminari
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.1)

--- a/app/controllers/api/v1/companies_controller.rb
+++ b/app/controllers/api/v1/companies_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  module V1
+    class CompaniesController < ApplicationController
+      def index
+        @companies = Company.by_name(params[:name])
+                
+        if @companies.any?
+          @companies = @companies.page(params[:page]).per(params[:per_page])
+          render json: @companies
+        else
+          render json: { message: 'No Company found with the given email' }, status: :not_found
+        end
+      end
+    end
+  end
+end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -9,5 +9,8 @@
 #
 
 class Company < ApplicationRecord
+
   has_many :people
+
+  scope :by_name, -> (name) { where('LOWER(name) LIKE ?', "%#{name.downcase}%") if name.present? }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,10 @@ Rails.application.routes.draw do
 
   resources :people, only: [:index, :new, :create]
   root to: 'people#index'
+
+  namespace :api do
+    namespace :v1 do
+      resources :companies, only: [:index]
+    end
+  end
 end

--- a/spec/controllers/api/v1/companies_controller_spec.rb
+++ b/spec/controllers/api/v1/companies_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::CompaniesController, type: :controller do
+  describe 'GET #index' do
+    let!(:company) { Company.create(name: 'DigitalOcean') }
+
+    context 'when name exists' do
+      before { get :index, params: { name: 'Digital', page: 1, per_page: 10 } }
+
+      it 'returns the company with the given name' do
+        expect(JSON.parse(response.body).first['name']).to eq('DigitalOcean')
+      end
+
+      it 'returns status code 200' do
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'when name does not exist' do
+      before { get :index, params: { name: 'Nonexistent', page: 1, per_page: 10 } }
+
+      it 'returns a not found message' do
+        expect(JSON.parse(response.body)['message']).to eq('No Company found with the given email')
+      end
+
+      it 'returns status code 404' do
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -12,4 +12,26 @@ require 'rails_helper'
 
 RSpec.describe Company, type: :model do
   it { is_expected.to have_many :people }
+  describe '.by_name' do
+    let!(:company) { Company.create(name: 'DigitalOcean') }
+
+    context 'when name exists' do
+      it 'returns the company with the given name' do
+        expect(Company.by_name('Digital')).to include(company)
+      end
+    end
+
+    context 'when name does not exist' do
+      it 'returns an empty relation' do
+        expect(Company.by_name('Nonexistent')).to be_empty
+      end
+    end
+
+    context 'when name is nil' do
+      it 'returns all companies' do
+        other_company = Company.create(name: 'OtherCompany')
+        expect(Company.by_name(nil)).to match_array([company, other_company])
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Create an API endpoint that exposes Companies to the public with filtering based on case insensitive partial matches to company name with pagination. Example GET request: { name: 'digital', page: 1, per_page: 10 }**

- Added api endpoints for getting all companies filter by insensitive name.
- Added scope for filter name in model.
- Added test case for both model and api controller.
- endpoints for api :- `http://localhost:3000/api/v1/companies?name=abc&page=1&per_page=10`