### PR TITLE
Api: multiple companies creation api with basic authentication - 12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem "rspec-rails"
   gem "pry-rails"
+  gem "dotenv-rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,10 @@ GEM
     diff-lcs (1.5.0)
     digest (3.1.0)
     docile (1.4.0)
+    dotenv (3.1.2)
+    dotenv-rails (3.1.2)
+      dotenv (= 3.1.2)
+      railties (>= 6.1)
     erubi (1.10.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
@@ -275,6 +279,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  dotenv-rails
   factory_bot_rails
   faker
   jbuilder

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  module V1
+    class ApplicationController < ActionController::API
+      include ActionController::HttpAuthentication::Basic::ControllerMethods
+
+      before_action :authenticate
+
+      private
+
+      def authenticate
+        authenticate_or_request_with_http_basic do |username, password|
+          username == ENV['API_USERNAME'] && password == ENV['API_PASSWORD']        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -9,7 +9,8 @@ module Api
 
       def authenticate
         authenticate_or_request_with_http_basic do |username, password|
-          username == ENV['API_USERNAME'] && password == ENV['API_PASSWORD']        end
+          username == ENV['API_USERNAME'] && password == ENV['API_PASSWORD']        
+        end
       end
     end
   end

--- a/app/controllers/api/v1/companies_controller.rb
+++ b/app/controllers/api/v1/companies_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  module V1
+    class CompaniesController < ApplicationController
+      def create
+        companies = Company.create!(company_params[:companies])
+        render json: { companies: companies }, status: :created
+      rescue ActiveRecord::RecordInvalid => e
+        render json: { error: e.message }, status: :unprocessable_entity
+      end
+    
+      private
+    
+      def company_params
+        params.permit(companies: [:name])
+      end
+    end
+  end  
+end  

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,10 @@ Rails.application.routes.draw do
 
   resources :people, only: [:index, :new, :create]
   root to: 'people#index'
+
+  namespace :api do
+    namespace :v1 do
+      resources :companies, only: [:create]
+    end
+  end
 end

--- a/spec/controllers/api/v1/companies_controller_spec.rb
+++ b/spec/controllers/api/v1/companies_controller_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::CompaniesController, type: :controller do
+  describe 'POST #create' do
+    let(:valid_attributes) do
+      { companies: [{ name: 'DigitalOcean' }, { name: 'GitHub' }] }
+    end
+
+    context 'when the request includes valid authentication headers' do
+      before do
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(ENV['API_USERNAME'], ENV['API_PASSWORD'])
+        post :create, params: valid_attributes
+      end
+
+      it 'returns status code 201' do
+        expect(response).to have_http_status(201)
+      end
+    end
+
+    context 'when the request does not include valid authentication headers' do
+      before { post :create, params: valid_attributes }
+
+      it 'returns status code 401' do
+        expect(response).to have_http_status(401)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Create an API endpoint that exposes Company creation via JSON with basic authentication allowing for the creation of multiple companies. It should return a response with company objects including their newly created IDs Example POST request: { companies: [{ name: 'Foo Bar, Inc' }, ...] }**

- Added basic authentication in `application_controller.rb` 
- Used ENV variable for authenticating the apis.
- Make API for creation of companies.
- Write test case for the creation api.

**Running api instruction :-** 

- setup `.env` with `API_USERNAME` and `API_PASSWORD`
- run api with curl
- `curl -u your_username:your_password -X POST -H "Content-Type: application/json" \
  -d '{"companies":[{"name":"Foo Bar, Inc"}, {"name":"Baz Quux, LLC"}]}' \
  http://localhost:3000/companies`

- you can use postman also

1. Open Postman.
2. Create a new POST request.
3. Set the request URL to http://localhost:3000/companies.
4. Select "Basic Auth" in the "Authorization" tab and enter your username and password.
5. In the "Body" tab, select "raw" and "JSON" and enter the JSON payload:

`{
  "companies": [
    { "name": "Foo Bar, Inc" },
    { "name": "Baz Quux, LLC" }
  ]
}
`
     6. Send the request.
